### PR TITLE
fix: update `TypstAsLibError` to use correct arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.14.4] - 2025-06-13
+
+- More informative typst errors (https://github.com/Relacibo/typst-as-lib/pull/13 by niusia-ua)
+
 ## [0.14.3] - 2025-05-06
 
 - Added feature `typst-html`, that allows you to output the document to html. (Also added example for html)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "typst-as-lib"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "binstall-tar",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typst-as-lib"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 license = "MIT"
 description = "Small wrapper for typst that makes it easier to use it as a templating engine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,13 +539,13 @@ struct InjectLocation {
 
 #[derive(Debug, Clone, Error)]
 pub enum TypstAsLibError {
-    #[error("Typst source error: {}", 0.to_string())]
+    #[error("Typst source error: {0:?}")]
     TypstSource(EcoVec<SourceDiagnostic>),
-    #[error("Typst file error: {}", 0.to_string())]
+    #[error("Typst file error: {0}")]
     TypstFile(#[from] FileError),
     #[error("Source file does not exist in collection: {0:?}")]
     MainSourceFileDoesNotExist(FileId),
-    #[error("Typst hinted String: {}", 0.to_string())]
+    #[error("Typst hinted String: {0:?}")]
     HintedString(HintedString),
     #[error("Unspecified: {0}!")]
     Unspecified(ecow::EcoString),


### PR DESCRIPTION
This patch fixes the issue with the `TypstAsLibError`.

Before that, `0.to_string()` was used to format the underlying error argument.
It means `convert an integer 0 to a string`, but not `convert the first tuple field to a string`.
See `thiserror`'s reference: <https://docs.rs/thiserror/latest/thiserror/#:~:text=MAX)%5D%0A%20%20%20%20InvalidLookahead(u32)%2C%0A%7D-,If%20one%20of%20the%20additional%20expression%20arguments%20needs%20to%20refer%20to,.,-%23%5Bderive(Error%2C%20Debug>.

Because of this, the resulting errors were completely uninformative.

I fixed this issue by using a correct reference to the arguments for errors.
Note that now `TypstSource` and `HintedString` use the `Debug` trait to render the error (they don't have the `Display` trait implemented), and `TypstFile` uses the `Display` trait.