### PR TITLE
[Draft] Package support in Web/Wasm via Async support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2851,7 @@ dependencies = [
 name = "typst-as-lib"
 version = "0.14.4"
 dependencies = [
+ "async-trait",
  "binstall-tar",
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,12 @@ keywords = ["template", "typst"]
 categories = ["template-engine"]
 
 [features]
+# undo this default once dev is done on async.
+default = ["async-reqwest"]
 packages = ["dep:binstall-tar", "dep:flate2"]
 ureq = ["dep:ureq"]
-reqwest = ["dep:reqwest", "dep:bytes"]
+reqwest = ["dep:reqwest", "dep:bytes", "reqwest/blocking"]
+async-reqwest = ["dep:reqwest", "dep:bytes"]
 typst-kit-fonts = ["dep:typst-kit", "typst-kit/fonts"]
 typst-kit-embed-fonts = ["typst-kit?/embed-fonts"]
 typst-html = []
@@ -28,8 +31,9 @@ thiserror = "2.0"
 typst = "0.13"
 ureq = { version = "3.0", optional = true }
 typst-kit = { version = "0.13", default-features = false, optional = true }
-reqwest = { version = "0.12", features = ["blocking"], optional = true }
+reqwest = { version = "0.12", optional = true }
 bytes = { version = "1.10",  optional = true }
+async-trait = "0.1.88"
 
 [dev-dependencies]
 derive_typst_intoval = "0.3.0"
@@ -40,6 +44,11 @@ typst = "0.13.1"
 [[example]]
 name = "resolve_packages"
 required-features = ["packages"]
+
+
+[[example]]
+name = "async_resolve_packages"
+required-features = ["packages", "async-reqwest"]
 
 [[example]]
 name = "font_searcher"

--- a/examples/async_resolve_packages.rs
+++ b/examples/async_resolve_packages.rs
@@ -1,0 +1,13 @@
+static OUTPUT: &str = "./examples/output.pdf";
+static TEMPLATE_FILE: &str = include_str!("./templates/resolve_files.typ");
+static ROOT: &str = "./examples/templates";
+static FONT: &[u8] = include_bytes!("./fonts/texgyrecursor-regular.otf");
+
+#[cfg(any(feature = "async-reqwest"))]
+fn main() {
+}
+
+#[cfg(not(any(feature = "async-reqwest")))]
+fn main() {
+    eprintln!(r#"Enable the async-reqwest feature"#)
+}

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -15,6 +15,7 @@ use crate::{
     conversions::{IntoBytes, IntoFileId, IntoSource},
     util::{bytes_to_source, not_found},
 };
+use async_trait::async_trait;
 
 // https://github.com/typst/typst/blob/16736feb13eec87eb9ca114deaeb4f7eeb7409d2/crates/typst-kit/src/package.rs#L18
 /// The default packages sub directory within the package and package cache paths.
@@ -23,6 +24,12 @@ pub const DEFAULT_PACKAGES_SUBDIR: &str = "typst/packages";
 pub trait FileResolver {
     fn resolve_binary(&self, id: FileId) -> FileResult<Cow<Bytes>>;
     fn resolve_source(&self, id: FileId) -> FileResult<Cow<Source>>;
+}
+
+#[async_trait]
+pub trait AsyncFileResolver {
+    async fn resolve_binary_async(&self, id: FileId) -> FileResult<Cow<Bytes>>;
+    async fn resolve_source_async(&self, id: FileId) -> FileResult<Cow<Source>>;
 }
 
 #[derive(Debug, Clone)]
@@ -47,6 +54,17 @@ impl FileResolver for MainSourceFileResolver {
             return Ok(Cow::Borrowed(main_source));
         }
         Err(not_found(id))
+    }
+}
+
+#[async_trait]
+impl AsyncFileResolver for MainSourceFileResolver {
+    async fn resolve_binary_async(&self, id: FileId) -> FileResult<Cow<Bytes>> {
+        self.resolve_binary(id)
+    }
+
+    async fn resolve_source_async(&self, id: FileId) -> FileResult<Cow<Source>> {
+        self.resolve_source(id)
     }
 }
 
@@ -85,6 +103,17 @@ impl FileResolver for StaticSourceFileResolver {
     }
 }
 
+#[async_trait]
+impl AsyncFileResolver for StaticSourceFileResolver {
+    async fn resolve_binary_async(&self, id: FileId) -> FileResult<Cow<Bytes>> {
+        self.resolve_binary(id)
+    }
+
+    async fn resolve_source_async(&self, id: FileId) -> FileResult<Cow<Source>> {
+        self.resolve_source(id)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StaticFileResolver {
     binaries: HashMap<FileId, Bytes>,
@@ -115,6 +144,17 @@ impl FileResolver for StaticFileResolver {
 
     fn resolve_source(&self, id: FileId) -> FileResult<Cow<Source>> {
         Err(not_found(id))
+    }
+}
+
+#[async_trait]
+impl AsyncFileResolver for StaticFileResolver {
+    async fn resolve_binary_async(&self, id: FileId) -> FileResult<Cow<Bytes>> {
+        self.resolve_binary(id)
+    }
+
+    async fn resolve_source_async(&self, id: FileId) -> FileResult<Cow<Source>> {
+        self.resolve_source(id)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,15 @@ impl TypstEngine<TypstTemplateMainFile> {
         let TypstTemplateMainFile { source_id } = self.template;
         self.do_compile(source_id, None)
     }
+
+    #[cfg(feature = "async-reqwest")]
+    pub async fn compile_async<Doc>(&self) -> Warned<Result<Doc, TypstAsLibError>>
+    where
+        Doc: Document,
+    {
+        let TypstTemplateMainFile { source_id } = self.template;
+        self.do_compile(source_id, None)
+    }
 }
 
 pub struct TypstTemplateEngineBuilder<T = TypstTemplateCollection> {


### PR DESCRIPTION
As far as I can tell, the main thing in the way of package support on web is support for an async API (as blocking requests aren't possible or desired on the web). This likely means duplicating a bunch of methods and storages _and_ relying on the `async_traits` crate.

I'm opening this PR early to open discussion, mostly. I've tried vendoring this crate before and it's been a bit more than what I've had capacity to do, but I'd like to hack at it here and there now I've had a look at the internals after the recent-ish rewrite. That being said I'm stretched a bit thin right now, so I'm not making promises.