### PR TITLE
feat: add automatic package bundling feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,13 +3026,18 @@ dependencies = [
  "dirs",
  "ecow",
  "flate2",
+ "include_dir",
+ "regex",
  "reqwest",
  "thiserror",
+ "toml",
  "typst",
  "typst-html",
  "typst-kit",
  "typst-pdf",
+ "typst-syntax",
  "ureq",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 keywords = ["template", "typst"]
 categories = ["template-engine"]
 
+[package.metadata.typst-as-lib]
+template-dir = "./examples/templates"
+
 [features]
 packages = ["dep:binstall-tar", "dep:flate2"]
 ureq = ["dep:ureq"]
@@ -16,6 +19,7 @@ reqwest = ["dep:reqwest", "dep:bytes"]
 typst-kit-fonts = ["dep:typst-kit", "typst-kit/fonts"]
 typst-kit-embed-fonts = ["typst-kit?/embed-fonts"]
 typst-html = []
+package-bundling = ["dep:include_dir", "packages"]
 
 [dependencies]
 binstall-tar = { version = "0.4", optional = true }
@@ -24,6 +28,7 @@ comemo = "0.5"
 dirs = "6.0"
 ecow = "0.2"
 flate2 = { version = "1.0", optional = true }
+include_dir = { version = "0.7", optional = true }
 thiserror = "2.0"
 typst = "0.14"
 ureq = { version = "3.1", optional = true }
@@ -37,6 +42,16 @@ typst-pdf = "0.14.2"
 typst-html = "0.14.0"
 typst = "0.14.2"
 
+[build-dependencies]
+binstall-tar = "0.4"
+flate2 = "1.0"
+regex = "1"
+toml = "0.8"
+typst-syntax = "0.14"
+ureq = { version = "3.1", optional = true }
+reqwest = { version = "0.12", features = ["blocking"], optional = true }
+walkdir = "2"
+
 [[example]]
 name = "resolve_packages"
 required-features = ["packages"]
@@ -48,3 +63,7 @@ required-features = ["typst-kit-fonts", "typst-kit-embed-fonts"]
 [[example]]
 name = "html"
 required-features = ["typst-html"]
+
+[[example]]
+name = "auto_packages"
+required-features = ["package-bundling", "ureq"]

--- a/README.md
+++ b/README.md
@@ -162,6 +162,54 @@ let template = TypstEngine::build()
 
 Note that the Cache Wrapper created with the call to `into_cached(self)` only caches the `Source` files (each single file lazily) here and the `InMemoryCache` caches all binaries (eagerly after the first download of the whole package, which is triggered (lazily), when requested in a typst script).
 
+### Automatic Package Bundling
+
+The `package-bundling` feature automatically downloads and embeds Typst packages at build time.
+
+The features `package-bundling` and one of `ureq` or `reqwest` need to be enabled.
+
+Configure the template directory in your `Cargo.toml`:
+
+```toml
+[package.metadata.typst-as-lib]
+template-dir = "./templates"
+
+[dependencies]
+typst-as-lib = { version = "0.15", features = ["package-bundling", "ureq"] }
+```
+
+Then use it in your code:
+
+```rust
+let engine = TypstEngine::builder()
+    .main_file(TEMPLATE_FILE)
+    .fonts([FONT])
+    .with_bundled_packages()
+    .build();
+```
+
+Alternatively, instead of using Cargo.toml metadata, you can set an environment variable (useful for CI/CD):
+
+```bash
+export TYPST_TEMPLATE_DIR=./templates
+cargo build
+```
+
+Or use `.cargo/config.toml`:
+
+```toml
+[env]
+TYPST_TEMPLATE_DIR = "./templates"
+```
+
+This approach has zero runtime dependencies - no filesystem or internet access is needed at runtime. The binary works in completely offline environments. Transitive dependencies are automatically resolved and embedded.
+
+See [auto_packages example](https://github.com/Relacibo/typst-as-lib/blob/main/examples/auto_packages.rs).
+
+```bash
+cargo r --example=auto_packages --features=package-bundling,ureq
+```
+
 ### Local files and remote packages example
 
 See example [resolve_packages](https://github.com/Relacibo/typst-as-lib/blob/main/examples/resolve_packages.rs) which uses the file and the package resolver.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,415 @@
+#[cfg(feature = "package-bundling")]
+fn main() {
+    use std::env;
+    use std::fs;
+    use std::io::Read;
+    use std::path::{Path, PathBuf};
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let pkg_dir = out_dir.join("typst_packages");
+
+    // Priority 1: Environment variable (highest priority - explicit override)
+    // Priority 2: Cargo.toml metadata (project configuration)
+    let template_dir = env::var("TYPST_TEMPLATE_DIR")
+        .ok()
+        .or_else(|| {
+            // Read Cargo.toml to get metadata
+            let cargo_toml_path =
+                Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("Cargo.toml");
+            fs::read_to_string(cargo_toml_path)
+                .ok()
+                .and_then(|content| content.parse::<toml::Table>().ok())
+                .and_then(|manifest| {
+                    manifest
+                        .get("package")?
+                        .get("metadata")?
+                        .get("typst-as-lib")?
+                        .get("template-dir")?
+                        .as_str()
+                        .map(|s| s.to_string())
+                })
+        })
+        .unwrap_or_else(|| {
+            eprintln!(
+                "\n\
+                ERROR: Template directory not configured for package-bundling feature.\n\
+                \n\
+                Choose ONE of the following solutions:\n\
+                \n\
+                Option 1 (Recommended): Add to Cargo.toml\n\
+                \n\
+                  [package.metadata.typst-as-lib]\n\
+                  template-dir = \"./templates\"\n\
+                \n\
+                Option 2: Set environment variable\n\
+                \n\
+                  export TYPST_TEMPLATE_DIR=./templates\n\
+                  cargo build\n\
+                \n\
+                Option 3: Use .cargo/config.toml\n\
+                \n\
+                  [env]\n\
+                  TYPST_TEMPLATE_DIR = \"./templates\"\n\
+            "
+            );
+            std::process::exit(1);
+        });
+
+    println!("cargo:rerun-if-env-changed=TYPST_TEMPLATE_DIR");
+    println!("cargo:rerun-if-changed={}", template_dir);
+
+    let packages = extract_packages(&template_dir);
+
+    if packages.is_empty() {
+        eprintln!("No packages found in templates");
+        fs::create_dir_all(&pkg_dir).ok();
+    } else {
+        download_packages(&packages, &pkg_dir);
+    }
+
+    println!(
+        "cargo:rustc-env=TYPST_BUNDLED_PACKAGES_DIR={}",
+        pkg_dir.display()
+    );
+
+    fn is_valid_identifier(s: &str) -> bool {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    }
+
+    fn is_valid_version(s: &str) -> bool {
+        !s.is_empty() && s.chars().all(|c| c.is_numeric() || c == '.')
+    }
+
+    fn parse_package_specifier(path: &str) -> Option<(String, String, String)> {
+        // Package imports start with @
+        if !path.starts_with('@') {
+            return None;
+        }
+
+        let path = &path[1..]; // Remove @
+
+        // Split namespace/name:version
+        let parts: Vec<&str> = path.split('/').collect();
+        if parts.len() != 2 {
+            return None;
+        }
+
+        let namespace = parts[0].to_string();
+        let name_version = parts[1];
+
+        // Split name and version
+        let nv_parts: Vec<&str> = name_version.split(':').collect();
+        if nv_parts.len() != 2 {
+            return None;
+        }
+
+        let name = nv_parts[0].to_string();
+        let version = nv_parts[1].to_string();
+
+        // Validate format
+        if !is_valid_identifier(&namespace)
+            || !is_valid_identifier(&name)
+            || !is_valid_version(&version)
+        {
+            return None;
+        }
+
+        Some((namespace, name, version))
+    }
+
+    fn parse_packages_from_source(content: &str) -> Result<Vec<(String, String, String)>, String> {
+        #[allow(unused_imports)]
+        use typst_syntax::{
+            Source,
+            ast::{AstNode, Expr, Markup},
+        };
+
+        // Parse source into AST
+        let source = Source::detached(content);
+        let root_node = source.root();
+
+        // Cast SyntaxNode to Markup AST node
+        // AstNode trait must be in scope for cast method
+        let root: Markup = match root_node.cast() {
+            Some(markup) => markup,
+            None => return Err("Failed to cast root node to Markup".to_string()),
+        };
+
+        let mut packages = Vec::new();
+
+        // Iterate through all expressions
+        for expr in root.exprs() {
+            // Look for import expressions
+            if let Expr::ModuleImport(import) = expr {
+                // Extract the import source
+                let source_expr = import.source();
+
+                // Check if source is a string literal
+                if let Expr::Str(str_node) = source_expr {
+                    let import_path = str_node.get();
+
+                    // Parse package specifier
+                    if let Some(pkg) = parse_package_specifier(&import_path) {
+                        packages.push(pkg);
+                    }
+                }
+            }
+        }
+
+        Ok(packages)
+    }
+
+    fn extract_packages(dir: &str) -> Vec<(String, String, String)> {
+        use std::collections::HashSet;
+        use walkdir::WalkDir;
+
+        let mut packages = HashSet::new();
+
+        for entry in WalkDir::new(dir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "typ"))
+        {
+            if let Ok(content) = fs::read_to_string(entry.path()) {
+                // Parse with typst-syntax
+                match parse_packages_from_source(&content) {
+                    Ok(found_packages) => {
+                        packages.extend(found_packages);
+                    }
+                    Err(e) => {
+                        // Log but don't fail - graceful degradation
+                        eprintln!(
+                            "Failed to parse {}: {}",
+                            entry.path().display(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        packages.into_iter().collect()
+    }
+
+    fn download_packages(packages: &[(String, String, String)], dest: &Path) {
+        use std::collections::{HashSet, VecDeque};
+
+        fs::create_dir_all(dest).unwrap();
+        let mut failed_packages = Vec::new();
+        let mut to_download = VecDeque::from(packages.to_vec());
+        let mut downloaded = HashSet::new();
+
+        while let Some((namespace, name, version)) = to_download.pop_front() {
+            // Skip if already downloaded or attempted
+            let pkg_key = format!("{}/{}/{}", namespace, name, version);
+            if !downloaded.insert(pkg_key.clone()) {
+                continue;
+            }
+
+            let pkg_dir = dest.join(&namespace).join(&name).join(&version);
+
+            // Caching: skip if exists (but still check dependencies)
+            if pkg_dir.exists() {
+                eprintln!("Cached: {}/{}-{}", namespace, name, version);
+            } else {
+                eprintln!(
+                    "Downloading: {}/{}-{}",
+                    namespace, name, version
+                );
+
+                let url = format!(
+                    "https://packages.typst.org/{}/{}-{}.tar.gz",
+                    namespace, name, version
+                );
+
+                match download_and_extract(&url, &pkg_dir) {
+                    Ok(_) => eprintln!("✓ {}/{}-{}", namespace, name, version),
+                    Err(e) => {
+                        eprintln!(
+                            "✗ Failed to download {}/{}-{}: {}",
+                            namespace, name, version, e
+                        );
+                        failed_packages.push(format!("{}/{}-{}", namespace, name, version));
+                        continue;
+                    }
+                }
+            }
+
+            // 1. Parse typst.toml for explicit dependencies
+            let toml_path = pkg_dir.join("typst.toml");
+            if let Ok(content) = fs::read_to_string(&toml_path)
+                && let Ok(manifest) = content.parse::<toml::Table>()
+                && let Some(deps) = manifest.get("package").and_then(|p| p.get("dependencies"))
+                && let Some(deps_table) = deps.as_table()
+            {
+                for (dep_name, dep_value) in deps_table {
+                    if let Some(dep_str) = dep_value.as_str()
+                        && let Some((dep_ns, dep_ver)) = dep_str.split_once(':')
+                    {
+                        to_download.push_back((
+                            dep_ns.to_string(),
+                            dep_name.clone(),
+                            dep_ver.to_string(),
+                        ));
+                    }
+                }
+            }
+
+            // 2. Scan package's .typ files for implicit dependencies
+            let pkg_deps = extract_packages(pkg_dir.to_str().unwrap());
+            for (dep_ns, dep_name, dep_ver) in pkg_deps {
+                to_download.push_back((dep_ns, dep_name, dep_ver));
+            }
+        }
+
+        // Abort build if any packages failed to download
+        if !failed_packages.is_empty() {
+            panic!(
+                "Failed to download {} package(s):\n  - {}\n\n\
+                Please check your internet connection and try again.\n\
+                Downloaded packages are cached in OUT_DIR and won't be re-downloaded.",
+                failed_packages.len(),
+                failed_packages.join("\n  - ")
+            );
+        }
+    }
+
+    #[cfg(feature = "ureq")]
+    fn download_and_extract(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        let response = ureq::get(url).call()?;
+        let (_, body) = response.into_parts();
+        let mut bytes = Vec::new();
+        body.into_reader().read_to_end(&mut bytes)?;
+        extract_tar_gz(&bytes, dest)
+    }
+
+    #[cfg(all(not(feature = "ureq"), feature = "reqwest"))]
+    fn download_and_extract(url: &str, dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        let client = reqwest::blocking::Client::new();
+        let bytes = client.get(url).send()?.bytes()?.to_vec();
+        extract_tar_gz(&bytes, dest)
+    }
+
+    fn extract_tar_gz(bytes: &[u8], dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        use binstall_tar::Archive;
+        use flate2::read::GzDecoder;
+
+        fs::create_dir_all(dest)?;
+        let gz = GzDecoder::new(bytes);
+        let mut archive = Archive::new(gz);
+        archive.unpack(dest)?;
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "package-bundling"))]
+fn main() {
+    // No-op when feature is disabled
+}
+
+#[cfg(all(test, feature = "package-bundling"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_package_specifier_valid() {
+        assert_eq!(
+            parse_package_specifier("@preview/cetz:0.3.2"),
+            Some((
+                "preview".to_string(),
+                "cetz".to_string(),
+                "0.3.2".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_package_specifier("@preview/polylux:0.3.1"),
+            Some((
+                "preview".to_string(),
+                "polylux".to_string(),
+                "0.3.1".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_package_specifier_no_at_sign() {
+        assert_eq!(parse_package_specifier("preview/cetz:0.3.2"), None);
+    }
+
+    #[test]
+    fn test_parse_package_specifier_invalid_format() {
+        assert_eq!(parse_package_specifier("@preview"), None);
+        assert_eq!(parse_package_specifier("@preview/cetz"), None);
+        assert_eq!(parse_package_specifier("@/cetz:0.3.2"), None);
+        assert_eq!(parse_package_specifier("@preview/:0.3.2"), None);
+    }
+
+    #[test]
+    fn test_parse_packages_from_source_simple() {
+        let content = r#"#import "@preview/cetz:0.3.2""#;
+        let packages = parse_packages_from_source(content).unwrap();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(
+            packages[0],
+            (
+                "preview".to_string(),
+                "cetz".to_string(),
+                "0.3.2".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_packages_ignores_comments() {
+        let content = r#"
+        // This should be ignored: @preview/fake:1.0.0
+        /* Also ignored: @preview/another:2.0.0 */
+        #import "@preview/cetz:0.3.2"
+        "#;
+        let packages = parse_packages_from_source(content).unwrap();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].1, "cetz");
+    }
+
+    #[test]
+    fn test_parse_packages_ignores_strings() {
+        let content = r#"
+        #let description = "Uses @preview/fake:1.0.0 for testing"
+        #import "@preview/cetz:0.3.2"
+        "#;
+        let packages = parse_packages_from_source(content).unwrap();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].1, "cetz");
+    }
+
+    #[test]
+    fn test_parse_packages_multiple_imports() {
+        let content = r#"
+        #import "@preview/cetz:0.3.2"
+        #import "@preview/polylux:0.3.1"
+        "#;
+        let packages = parse_packages_from_source(content).unwrap();
+        assert_eq!(packages.len(), 2);
+    }
+
+    #[test]
+    fn test_is_valid_identifier() {
+        assert!(is_valid_identifier("preview"));
+        assert!(is_valid_identifier("cetz"));
+        assert!(is_valid_identifier("my-package"));
+        assert!(is_valid_identifier("my_package"));
+        assert!(!is_valid_identifier(""));
+        assert!(!is_valid_identifier("my package"));
+    }
+
+    #[test]
+    fn test_is_valid_version() {
+        assert!(is_valid_version("0.3.2"));
+        assert!(is_valid_version("1.0.0"));
+        assert!(is_valid_version("2.1"));
+        assert!(!is_valid_version(""));
+        assert!(!is_valid_version("1.0.0-beta"));
+    }
+}

--- a/examples/auto_packages.rs
+++ b/examples/auto_packages.rs
@@ -1,0 +1,48 @@
+//! Automatic package bundling demo
+//!
+//! How to run:
+//! 1. export TYPST_TEMPLATE_DIR=./examples/templates
+//! 2. cargo build --example auto_packages --features package-bundling,ureq
+//! 3. cargo run --example auto_packages --features package-bundling,ureq
+
+#[cfg(feature = "package-bundling")]
+use std::fs;
+
+#[cfg(feature = "package-bundling")]
+use typst_as_lib::TypstEngine;
+
+static TEMPLATE: &str = include_str!("./templates/with_packages.typ");
+static FONT: &[u8] = include_bytes!("./fonts/texgyrecursor-regular.otf");
+static OUTPUT: &str = "./examples/output_auto.pdf";
+
+#[cfg(feature = "package-bundling")]
+fn main() {
+    println!("Building engine with bundled packages...");
+
+    let engine = TypstEngine::builder()
+        .main_file(TEMPLATE)
+        .fonts([FONT])
+        .with_bundled_packages() // Use embedded packages
+        .build();
+
+    println!("Compiling document...");
+
+    let doc = engine.compile().output.expect("Compilation failed");
+
+    println!("Generating PDF...");
+
+    let pdf = typst_pdf::pdf(&doc, &Default::default()).expect("PDF generation failed");
+
+    fs::write(OUTPUT, pdf).expect("Write failed");
+
+    println!("✓ PDF generated: {}", OUTPUT);
+    println!("  Packages served from embedded data (no filesystem access!)");
+}
+
+#[cfg(not(feature = "package-bundling"))]
+fn main() {
+    eprintln!("This example requires 'package-bundling' feature");
+    eprintln!("Run with:");
+    eprintln!("  export TYPST_TEMPLATE_DIR=./examples/templates");
+    eprintln!("  cargo run --example auto_packages --features package-bundling,ureq");
+}

--- a/examples/templates/with_packages.typ
+++ b/examples/templates/with_packages.typ
@@ -1,0 +1,16 @@
+// Automatic package bundling demo template
+#import "@preview/cetz:0.3.2"
+
+= Auto-Bundled Packages Demo
+
+This template uses packages that are automatically detected and embedded at build time.
+
+#cetz.canvas({
+    import cetz.draw: *
+
+    circle((0, 0), radius: 1, fill: blue.lighten(80%))
+    line((0, 0), (2, 1), stroke: 2pt + red)
+    content((1, 0.5), [Embedded!])
+})
+
+Packages are served directly from static data without filesystem access at runtime.

--- a/src/embedded_package_resolver.rs
+++ b/src/embedded_package_resolver.rs
@@ -1,0 +1,99 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use typst::diag::FileResult;
+use typst::foundations::Bytes;
+use typst::syntax::{FileId, Source};
+
+use crate::file_resolver::FileResolver;
+use crate::util::{bytes_to_source, not_found};
+
+/// FileResolver that serves packages embedded at compile time.
+///
+/// Packages downloaded by build.rs are embedded using the `include_dir!` macro,
+/// providing zero-overhead file resolution without filesystem access at runtime.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let engine = TypstEngine::builder()
+///     .main_file(template)
+///     .fonts([font])
+///     .with_bundled_packages()
+///     .build();
+/// ```
+#[derive(Debug)]
+pub struct EmbeddedPackageResolver {
+    files: HashMap<String, &'static [u8]>,
+}
+
+impl EmbeddedPackageResolver {
+    /// Create resolver from embedded packages directory
+    pub fn new() -> Self {
+        use include_dir::{Dir, include_dir};
+
+        // Use environment variable set by build.rs
+        // CRITICAL: env!() is evaluated at compile time
+        static PACKAGES: Dir<'static> = include_dir!("$TYPST_BUNDLED_PACKAGES_DIR");
+
+        let mut files = HashMap::new();
+        collect_files(&PACKAGES, &mut files);
+
+        Self { files }
+    }
+
+    /// Convert FileId to embedded file path.
+    ///
+    /// Uses same path convention as PackageResolver:
+    /// {namespace}/{name}/{version}/{vpath}
+    fn file_path(&self, id: FileId) -> String {
+        if let Some(pkg) = id.package() {
+            format!(
+                "{}/{}/{}/{}",
+                pkg.namespace.as_str(),
+                pkg.name.as_str(),
+                pkg.version,
+                id.vpath().as_rootless_path().display()
+            )
+        } else {
+            id.vpath().as_rootless_path().display().to_string()
+        }
+    }
+}
+
+impl Default for EmbeddedPackageResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileResolver for EmbeddedPackageResolver {
+    fn resolve_binary(&self, id: FileId) -> FileResult<Cow<'_, Bytes>> {
+        let path = self.file_path(id);
+
+        self.files
+            .get(&path)
+            .map(|&bytes| Cow::Owned(Bytes::new(bytes)))
+            .ok_or_else(|| not_found(id))
+    }
+
+    fn resolve_source(&self, id: FileId) -> FileResult<Cow<'_, Source>> {
+        let path = self.file_path(id);
+        let bytes = self.files.get(&path).ok_or_else(|| not_found(id))?;
+        let source = bytes_to_source(id, bytes)?;
+        Ok(Cow::Owned(source))
+    }
+}
+
+/// Recursively traverse include_dir's Dir to build HashMap
+fn collect_files(dir: &'static include_dir::Dir, map: &mut HashMap<String, &'static [u8]>) {
+    // file.path() returns full relative path from root
+    for file in dir.files() {
+        let path = file.path().display().to_string().replace('\\', "/");
+        map.insert(path, file.contents());
+    }
+
+    // Recursively process subdirectories
+    for subdir in dir.dirs() {
+        collect_files(subdir, map);
+    }
+}


### PR DESCRIPTION
## Summary

Adds optional automatic package management that downloads and embeds Typst packages at build time.

## Motivation

Currently, PackageFileResolver downloads packages at runtime, which requires internet access. For fully offline environments, this PR provides an alternative: automatic build-time bundling that embeds packages directly into the binary.

## Implementation

- **Feature flag**: `package-bundling` (optional, non-breaking)
- **Build script**: Parses templates using typst-syntax AST
- **Configuration**: Cargo.toml metadata or environment variable
- **Transitive dependencies**: Automatically resolved
- **Embedding**: Zero runtime footprint with `include_dir!`
- **API**: Simple `.with_bundled_packages()` method

## Benefits

- Automatic dependency management
- Zero runtime footprint (completely offline)
- Template-driven version updates

## Testing

- All existing tests pass
- New example: `cargo run --example auto_packages --features package-bundling,ureq`

I'm happy to make changes based on feedback!