### PR TITLE
Manually pre-populate package cache ahead of time in an async context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2626,12 +2626,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2931,16 +2931,28 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3137,6 +3149,7 @@ dependencies = [
  "flate2",
  "reqwest",
  "thiserror 2.0.18",
+ "tokio",
  "typst",
  "typst-html",
  "typst-kit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ derive_typst_intoval = "0.6.0"
 typst-pdf = "0.14.2"
 typst-html = "0.14.2"
 typst = "0.14.2"
+tokio = {version = "1.52.3", features = ["rt", "macros"]}
 
 [[example]]
 name = "resolve_packages"

--- a/src/package_resolver.rs
+++ b/src/package_resolver.rs
@@ -496,11 +496,11 @@ impl IntoCachedFileResolver for PackageResolver<FileSystemCache> {
     }
 }
 
-fn populate_packages(root: SyntaxNode, stack: &mut Vec<PackageSpec>, done: &HashSet<PackageSpec>) {
+fn find_and_queue_packages(root: SyntaxNode, stack: &mut Vec<PackageSpec>, done: &HashSet<PackageSpec>) {
     let mut ast_stack: Vec<_> = vec![&root];
     let mut import_nodes = vec![];
     while let Some(node) = ast_stack.pop() {
-        if let Some(import) = node.cast::<ModuleImport>() {
+        if let Some(_) = node.cast::<ModuleImport>() {
             for candidate in node.children() {
                 if let Some(str_candidate) = candidate.cast::<Str>()
                     && str_candidate.get().starts_with("@")
@@ -535,7 +535,7 @@ async fn async_prepopulate_dependencies<C: PackageResolverCache>(
     let mut package_stack: Vec<PackageSpec> = vec![];
     let client = reqwest::ClientBuilder::new().build().unwrap();
     for source in sources {
-        populate_packages(source.root().clone(), &mut package_stack, &packages_done);
+        find_and_queue_packages(source.root().clone(), &mut package_stack, &packages_done);
     }
     while let Some(spec) = package_stack.pop() {
         if packages_done.contains(&spec) {
@@ -570,7 +570,7 @@ async fn async_prepopulate_dependencies<C: PackageResolverCache>(
                 continue;
             }
             let source = parse(&content);
-            populate_packages(source, &mut package_stack, &packages_done);
+            find_and_queue_packages(source, &mut package_stack, &packages_done);
             files_done.insert(file_id);
         }
         let Ok(_) = cache.cache_archive(Archive::new(&archive_bytes[..]), &spec) else {

--- a/src/package_resolver.rs
+++ b/src/package_resolver.rs
@@ -507,7 +507,7 @@ fn find_and_queue_packages(
         if let Some(_) = node.cast::<ModuleImport>() {
             for candidate in node.children() {
                 if let Some(str_candidate) = candidate.cast::<Str>()
-                    && str_candidate.get().starts_with("@")
+                    && str_candidate.get().starts_with("@preview")
                 {
                     import_nodes.push(str_candidate);
                 }

--- a/src/package_resolver.rs
+++ b/src/package_resolver.rs
@@ -496,7 +496,11 @@ impl IntoCachedFileResolver for PackageResolver<FileSystemCache> {
     }
 }
 
-fn find_and_queue_packages(root: SyntaxNode, stack: &mut Vec<PackageSpec>, done: &HashSet<PackageSpec>) {
+fn find_and_queue_packages(
+    root: SyntaxNode,
+    stack: &mut Vec<PackageSpec>,
+    done: &HashSet<PackageSpec>,
+) {
     let mut ast_stack: Vec<_> = vec![&root];
     let mut import_nodes = vec![];
     while let Some(node) = ast_stack.pop() {

--- a/src/package_resolver.rs
+++ b/src/package_resolver.rs
@@ -1,5 +1,10 @@
 use std::{
-    borrow::Cow, collections::{HashMap, HashSet}, io::Read, path::{Path, PathBuf}, str::FromStr, sync::{Arc, Mutex}
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    io::Read,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::{Arc, Mutex},
 };
 
 use binstall_tar::Archive;
@@ -9,7 +14,11 @@ use flate2::read::GzDecoder;
 use typst::{
     diag::{FileError, FileResult, PackageError},
     foundations::Bytes,
-    syntax::{FileId, Source, VirtualPath, ast::{ImportItemPath, ModuleImport}, package::{PackageSpec, PackageVersion}},
+    syntax::{
+        FileId, Source, VirtualPath,
+        ast::{ModuleImport, Str},
+        package::{PackageSpec, PackageVersion},
+    },
 };
 
 use crate::{
@@ -17,8 +26,6 @@ use crate::{
     file_resolver::{DEFAULT_PACKAGES_SUBDIR, FileResolver},
     util::{bytes_to_source, not_found},
 };
-
-pub mod async_resolver;
 
 // https://github.com/typst/typst/blob/16736feb13eec87eb9ca114deaeb4f7eeb7409d2/crates/typst-kit/src/package.rs#L15
 /// The default Typst registry.
@@ -184,8 +191,6 @@ pub struct PackageResolver<C = ()> {
     #[cfg(feature = "reqwest")]
     #[allow(dead_code)]
     reqwest: reqwest::blocking::Client,
-    #[cfg(feature = "async-reqwest")]
-    async_reqwest: reqwest::Client,
     cache: C,
     request_retry_count: u32,
 }
@@ -268,7 +273,11 @@ impl<C> PackageResolver<C> {
     }
 
     fn format_url_from_package_spec(package_spec: &PackageSpec) -> String {
-        Self::format_url_for_request(&package_spec.namespace, &package_spec.name, &package_spec.version)
+        Self::format_url_for_request(
+            &package_spec.namespace,
+            &package_spec.name,
+            &package_spec.version,
+        )
     }
 
     #[cfg(feature = "ureq")]
@@ -486,18 +495,24 @@ impl IntoCachedFileResolver for PackageResolver<FileSystemCache> {
     }
 }
 
-
-fn populate_packages(
-    source: Source,
-    stack: &mut Vec<PackageSpec>,
-    done: &HashSet<PackageSpec>,
-
-) {
-    for import_name in source.root().children().filter_map(|line| line.cast::<ModuleImport>().map(|data| data.bare_name().ok()).flatten()) {
-        let is_package = import_name.as_str().starts_with('@');
-        if !is_package {
-            continue;
+fn populate_packages(source: Source, stack: &mut Vec<PackageSpec>, done: &HashSet<PackageSpec>) {
+    let mut ast_stack: Vec<_> = source.root().children().collect();
+    let mut import_nodes = vec![];
+    while let Some(node) = ast_stack.pop() {
+        if let Some(import) = node.cast::<ModuleImport>() {
+            dbg!(import);
+            for candidate in node.children() {
+                if let Some(str_candidate) = candidate.cast::<Str>() && str_candidate.get().starts_with("@") {
+                    dbg!(str_candidate);
+                    import_nodes.push(str_candidate);
+                }
+            }
+        } else {
+            ast_stack.extend(node.children());
         }
+    }
+    for import_name in import_nodes.into_iter().map(|import| import.get()) {
+        dbg!(&import_name);
         let spec = PackageSpec::from_str(&import_name.as_str()).unwrap();
         if done.contains(&spec) || stack.contains(&spec) {
             continue;
@@ -507,26 +522,25 @@ fn populate_packages(
 }
 
 /// Pre-populate the cache with package dependencies in an async context for a given set of sources.
+/// This doesn't pull in regular imports from 
 async fn async_prepopulate_dependencies<C: PackageResolverCache>(
-    resolver: &mut PackageResolver<C>,
-    sources: impl IntoIterator<Item=Source>,
-) -> FileResult<()> {
-    let mut packages_done: HashSet<PackageSpec> = HashSet::default();
-    let mut packages_failed: HashSet<PackageSpec> = HashSet::default();
+    cache: &mut C,
+    sources: impl IntoIterator<Item = Source>,
+) -> FileResult<HashSet<PackageSpec>> {
+    let mut packages_done: HashSet<PackageSpec> = HashSet::new();
+    let mut files_done: HashSet<FileId> = HashSet::new();
+    let mut packages_failed: HashSet<PackageSpec> = HashSet::new();
     let mut package_stack: Vec<PackageSpec> = vec![];
-    let mut package_files_stack: Vec<(PackageSpec, PathBuf)> = vec![];
     let client = reqwest::ClientBuilder::new().build().unwrap();
     for source in sources {
-
         populate_packages(source, &mut package_stack, &packages_done);
     }
     while let Some(spec) = package_stack.pop() {
         if packages_done.contains(&spec) {
             continue;
         }
-
         let url = PackageResolver::<()>::format_url_from_package_spec(&spec);
-        let mut archive = vec![];
+        let mut archive_bytes = vec![];
         let Ok(response) = client.get(url).send().await else {
             packages_failed.insert(spec.clone());
             continue;
@@ -537,29 +551,57 @@ async fn async_prepopulate_dependencies<C: PackageResolverCache>(
         };
 
         let mut decoder = GzDecoder::new(bytes.reader());
-        decoder.read_to_end(&mut archive)
+        decoder
+            .read_to_end(&mut archive_bytes)
             .map_err(|error| PackageError::MalformedArchive(Some(eco_format!("{error}"))))?;
-        let mut archive = Archive::new(&archive[..]);
+        let mut archive = Archive::new(&archive_bytes[..]);
         let entries = archive.entries().unwrap();
-        let names: Vec<_> = entries
-            .filter_map(|entry| entry.ok())
-            .filter_map(|entry| entry.path().ok().map(|data| data.to_path_buf()))
-            .collect();
-        for name in names {
-            let pair = (spec.clone(), name.clone());
-            if !packages_done.contains(&spec) && !package_files_stack.contains(&pair) {
-                package_files_stack.push(pair);
-            } 
-        }
-        resolver.cache.cache_archive(archive, &spec)?;
-        while let Some(pair) = package_files_stack.pop() {
-            let Ok(Some(source)) = resolver.cache.lookup_cached::<Source>(&spec, FileId::new(Some(spec.clone()), VirtualPath::new(pair.1))) else {
+        for path in entries
+            .filter_map(|entry| entry.ok()?.path().ok().map(|data| data.to_path_buf()))
+        {
+            let file_id = FileId::new(Some(spec.clone()), VirtualPath::new(path));
+            if files_done.contains(&file_id) {
+                continue;
+            }
+            let Ok(Some(source)) = cache.lookup_cached::<Source>(
+                &spec,
+                file_id,
+            ) else {
                 continue;
             };
             populate_packages(source, &mut package_stack, &packages_done);
+            files_done.insert(file_id);
         }
+        dbg!(cache.cache_archive(Archive::new(&archive_bytes[..]), &spec));
         packages_done.insert(spec);
-        
     }
-    Ok(())
+    Ok(packages_done)
+}
+
+#[cfg(test)]
+mod test_async_packages {
+    use std::iter;
+    use tokio;
+
+use typst::syntax::{FileId, Source, VirtualPath, parse};
+
+use crate::{cached_file_resolver::CachedFileResolver, file_resolver::FileResolver, package_resolver::{PackageResolver, PackageResolverCache, async_prepopulate_dependencies, populate_packages}};
+
+    const LOTS_OF_IMPORTS: &str =
+r#"
+#import "@preview/cetz:0.5.2"
+#import     "@preview/fletcher:0.5.8"
+#import "@preview/timeliney:0.4.0"
+#import "@preview/pinit:0.2.2"
+"#;
+    #[tokio::test]
+    async fn fetch_packages() {
+        let source = Source::new(FileId::new(None, VirtualPath::new("/testing.typ")), LOTS_OF_IMPORTS.to_owned());
+        let mut cache = PackageResolver::builder().with_in_memory_cache();
+        let x = async_prepopulate_dependencies(&mut cache.cache, iter::once(source)).await;
+        assert!(x.is_ok());
+        let set = x.unwrap();
+        dbg!(&set);
+        assert!(set.len() > 0, "empty!");
+    }
 }

--- a/src/package_resolver.rs
+++ b/src/package_resolver.rs
@@ -502,7 +502,9 @@ fn populate_packages(source: Source, stack: &mut Vec<PackageSpec>, done: &HashSe
         if let Some(import) = node.cast::<ModuleImport>() {
             dbg!(import);
             for candidate in node.children() {
-                if let Some(str_candidate) = candidate.cast::<Str>() && str_candidate.get().starts_with("@") {
+                if let Some(str_candidate) = candidate.cast::<Str>()
+                    && str_candidate.get().starts_with("@")
+                {
                     dbg!(str_candidate);
                     import_nodes.push(str_candidate);
                 }
@@ -522,7 +524,7 @@ fn populate_packages(source: Source, stack: &mut Vec<PackageSpec>, done: &HashSe
 }
 
 /// Pre-populate the cache with package dependencies in an async context for a given set of sources.
-/// This doesn't pull in regular imports from 
+/// This doesn't pull in regular imports from
 async fn async_prepopulate_dependencies<C: PackageResolverCache>(
     cache: &mut C,
     sources: impl IntoIterator<Item = Source>,
@@ -556,17 +558,14 @@ async fn async_prepopulate_dependencies<C: PackageResolverCache>(
             .map_err(|error| PackageError::MalformedArchive(Some(eco_format!("{error}"))))?;
         let mut archive = Archive::new(&archive_bytes[..]);
         let entries = archive.entries().unwrap();
-        for path in entries
-            .filter_map(|entry| entry.ok()?.path().ok().map(|data| data.to_path_buf()))
+        for path in
+            entries.filter_map(|entry| entry.ok()?.path().ok().map(|data| data.to_path_buf()))
         {
             let file_id = FileId::new(Some(spec.clone()), VirtualPath::new(path));
             if files_done.contains(&file_id) {
                 continue;
             }
-            let Ok(Some(source)) = cache.lookup_cached::<Source>(
-                &spec,
-                file_id,
-            ) else {
+            let Ok(Some(source)) = cache.lookup_cached::<Source>(&spec, file_id) else {
                 continue;
             };
             populate_packages(source, &mut package_stack, &packages_done);
@@ -583,12 +582,18 @@ mod test_async_packages {
     use std::iter;
     use tokio;
 
-use typst::syntax::{FileId, Source, VirtualPath, parse};
+    use typst::syntax::{FileId, Source, VirtualPath, parse};
 
-use crate::{cached_file_resolver::CachedFileResolver, file_resolver::FileResolver, package_resolver::{PackageResolver, PackageResolverCache, async_prepopulate_dependencies, populate_packages}};
+    use crate::{
+        cached_file_resolver::CachedFileResolver,
+        file_resolver::FileResolver,
+        package_resolver::{
+            PackageResolver, PackageResolverCache, async_prepopulate_dependencies,
+            populate_packages,
+        },
+    };
 
-    const LOTS_OF_IMPORTS: &str =
-r#"
+    const LOTS_OF_IMPORTS: &str = r#"
 #import "@preview/cetz:0.5.2"
 #import     "@preview/fletcher:0.5.8"
 #import "@preview/timeliney:0.4.0"
@@ -596,7 +601,10 @@ r#"
 "#;
     #[tokio::test]
     async fn fetch_packages() {
-        let source = Source::new(FileId::new(None, VirtualPath::new("/testing.typ")), LOTS_OF_IMPORTS.to_owned());
+        let source = Source::new(
+            FileId::new(None, VirtualPath::new("/testing.typ")),
+            LOTS_OF_IMPORTS.to_owned(),
+        );
         let mut cache = PackageResolver::builder().with_in_memory_cache();
         let x = async_prepopulate_dependencies(&mut cache.cache, iter::once(source)).await;
         assert!(x.is_ok());

--- a/src/package_resolver.rs
+++ b/src/package_resolver.rs
@@ -1,18 +1,15 @@
 use std::{
-    borrow::Cow,
-    collections::HashMap,
-    io::Read,
-    path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    borrow::Cow, collections::{HashMap, HashSet}, io::Read, path::{Path, PathBuf}, str::FromStr, sync::{Arc, Mutex}
 };
 
 use binstall_tar::Archive;
+use bytes::Buf;
 use ecow::eco_format;
 use flate2::read::GzDecoder;
 use typst::{
     diag::{FileError, FileResult, PackageError},
     foundations::Bytes,
-    syntax::{FileId, Source, VirtualPath, package::PackageSpec},
+    syntax::{FileId, Source, VirtualPath, ast::{ImportItemPath, ModuleImport}, package::{PackageSpec, PackageVersion}},
 };
 
 use crate::{
@@ -20,6 +17,8 @@ use crate::{
     file_resolver::{DEFAULT_PACKAGES_SUBDIR, FileResolver},
     util::{bytes_to_source, not_found},
 };
+
+pub mod async_resolver;
 
 // https://github.com/typst/typst/blob/16736feb13eec87eb9ca114deaeb4f7eeb7409d2/crates/typst-kit/src/package.rs#L15
 /// The default Typst registry.
@@ -185,6 +184,8 @@ pub struct PackageResolver<C = ()> {
     #[cfg(feature = "reqwest")]
     #[allow(dead_code)]
     reqwest: reqwest::blocking::Client,
+    #[cfg(feature = "async-reqwest")]
+    async_reqwest: reqwest::Client,
     cache: C,
     request_retry_count: u32,
 }
@@ -236,10 +237,7 @@ impl<C> PackageResolver<C> {
             version,
         } = package;
 
-        let url = format!(
-            "{}/{}/{}-{}.tar.gz",
-            PACKAGE_REPOSITORY_URL, namespace, name, version,
-        );
+        let url = Self::format_url_for_request(namespace, name, version);
 
         let mut reader = Err(PackageError::Other(None));
         for i in 0..*request_retry_count {
@@ -260,6 +258,17 @@ impl<C> PackageResolver<C> {
         cache
             .lookup_cached(package, id)
             .and_then(|f| f.ok_or_else(|| not_found(id)))
+    }
+
+    fn format_url_for_request(namespace: &str, name: &str, version: &PackageVersion) -> String {
+        format!(
+            "{}/{}/{}-{}.tar.gz",
+            PACKAGE_REPOSITORY_URL, namespace, name, version,
+        )
+    }
+
+    fn format_url_from_package_spec(package_spec: &PackageSpec) -> String {
+        Self::format_url_for_request(&package_spec.namespace, &package_spec.name, &package_spec.version)
     }
 
     #[cfg(feature = "ureq")]
@@ -475,4 +484,82 @@ impl IntoCachedFileResolver for PackageResolver<FileSystemCache> {
             .with_in_memory_source_cache()
             .with_in_memory_binary_cache()
     }
+}
+
+
+fn populate_packages(
+    source: Source,
+    stack: &mut Vec<PackageSpec>,
+    done: &HashSet<PackageSpec>,
+
+) {
+    for import_name in source.root().children().filter_map(|line| line.cast::<ModuleImport>().map(|data| data.bare_name().ok()).flatten()) {
+        let is_package = import_name.as_str().starts_with('@');
+        if !is_package {
+            continue;
+        }
+        let spec = PackageSpec::from_str(&import_name.as_str()).unwrap();
+        if done.contains(&spec) || stack.contains(&spec) {
+            continue;
+        }
+        stack.push(spec);
+    }
+}
+
+/// Pre-populate the cache with package dependencies in an async context for a given set of sources.
+async fn async_prepopulate_dependencies<C: PackageResolverCache>(
+    resolver: &mut PackageResolver<C>,
+    sources: impl IntoIterator<Item=Source>,
+) -> FileResult<()> {
+    let mut packages_done: HashSet<PackageSpec> = HashSet::default();
+    let mut packages_failed: HashSet<PackageSpec> = HashSet::default();
+    let mut package_stack: Vec<PackageSpec> = vec![];
+    let mut package_files_stack: Vec<(PackageSpec, PathBuf)> = vec![];
+    let client = reqwest::ClientBuilder::new().build().unwrap();
+    for source in sources {
+
+        populate_packages(source, &mut package_stack, &packages_done);
+    }
+    while let Some(spec) = package_stack.pop() {
+        if packages_done.contains(&spec) {
+            continue;
+        }
+
+        let url = PackageResolver::<()>::format_url_from_package_spec(&spec);
+        let mut archive = vec![];
+        let Ok(response) = client.get(url).send().await else {
+            packages_failed.insert(spec.clone());
+            continue;
+        };
+        let Ok(bytes) = response.bytes().await else {
+            packages_failed.insert(spec.clone());
+            continue;
+        };
+
+        let mut decoder = GzDecoder::new(bytes.reader());
+        decoder.read_to_end(&mut archive)
+            .map_err(|error| PackageError::MalformedArchive(Some(eco_format!("{error}"))))?;
+        let mut archive = Archive::new(&archive[..]);
+        let entries = archive.entries().unwrap();
+        let names: Vec<_> = entries
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| entry.path().ok().map(|data| data.to_path_buf()))
+            .collect();
+        for name in names {
+            let pair = (spec.clone(), name.clone());
+            if !packages_done.contains(&spec) && !package_files_stack.contains(&pair) {
+                package_files_stack.push(pair);
+            } 
+        }
+        resolver.cache.cache_archive(archive, &spec)?;
+        while let Some(pair) = package_files_stack.pop() {
+            let Ok(Some(source)) = resolver.cache.lookup_cached::<Source>(&spec, FileId::new(Some(spec.clone()), VirtualPath::new(pair.1))) else {
+                continue;
+            };
+            populate_packages(source, &mut package_stack, &packages_done);
+        }
+        packages_done.insert(spec);
+        
+    }
+    Ok(())
 }

--- a/src/package_resolver.rs
+++ b/src/package_resolver.rs
@@ -15,9 +15,10 @@ use typst::{
     diag::{FileError, FileResult, PackageError},
     foundations::Bytes,
     syntax::{
-        FileId, Source, VirtualPath,
+        FileId, Source, SyntaxNode, VirtualPath,
         ast::{ModuleImport, Str},
         package::{PackageSpec, PackageVersion},
+        parse,
     },
 };
 
@@ -495,17 +496,15 @@ impl IntoCachedFileResolver for PackageResolver<FileSystemCache> {
     }
 }
 
-fn populate_packages(source: Source, stack: &mut Vec<PackageSpec>, done: &HashSet<PackageSpec>) {
-    let mut ast_stack: Vec<_> = source.root().children().collect();
+fn populate_packages(root: SyntaxNode, stack: &mut Vec<PackageSpec>, done: &HashSet<PackageSpec>) {
+    let mut ast_stack: Vec<_> = vec![&root];
     let mut import_nodes = vec![];
     while let Some(node) = ast_stack.pop() {
         if let Some(import) = node.cast::<ModuleImport>() {
-            dbg!(import);
             for candidate in node.children() {
                 if let Some(str_candidate) = candidate.cast::<Str>()
                     && str_candidate.get().starts_with("@")
                 {
-                    dbg!(str_candidate);
                     import_nodes.push(str_candidate);
                 }
             }
@@ -514,7 +513,6 @@ fn populate_packages(source: Source, stack: &mut Vec<PackageSpec>, done: &HashSe
         }
     }
     for import_name in import_nodes.into_iter().map(|import| import.get()) {
-        dbg!(&import_name);
         let spec = PackageSpec::from_str(&import_name.as_str()).unwrap();
         if done.contains(&spec) || stack.contains(&spec) {
             continue;
@@ -523,8 +521,10 @@ fn populate_packages(source: Source, stack: &mut Vec<PackageSpec>, done: &HashSe
     }
 }
 
-/// Pre-populate the cache with package dependencies in an async context for a given set of sources.
-/// This doesn't pull in regular imports from
+/// Pre-populate the cache with package dependencies in an async context for a
+/// given set of sources.
+/// This doesn't pull in regular imports from the sources passed to it, so make
+/// sure to pass all source files from a given template.
 async fn async_prepopulate_dependencies<C: PackageResolverCache>(
     cache: &mut C,
     sources: impl IntoIterator<Item = Source>,
@@ -535,7 +535,7 @@ async fn async_prepopulate_dependencies<C: PackageResolverCache>(
     let mut package_stack: Vec<PackageSpec> = vec![];
     let client = reqwest::ClientBuilder::new().build().unwrap();
     for source in sources {
-        populate_packages(source, &mut package_stack, &packages_done);
+        populate_packages(source.root().clone(), &mut package_stack, &packages_done);
     }
     while let Some(spec) = package_stack.pop() {
         if packages_done.contains(&spec) {
@@ -558,22 +558,28 @@ async fn async_prepopulate_dependencies<C: PackageResolverCache>(
             .map_err(|error| PackageError::MalformedArchive(Some(eco_format!("{error}"))))?;
         let mut archive = Archive::new(&archive_bytes[..]);
         let entries = archive.entries().unwrap();
-        for path in
-            entries.filter_map(|entry| entry.ok()?.path().ok().map(|data| data.to_path_buf()))
-        {
+        for (path, content) in entries.filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path().ok().map(|data| data.to_path_buf())?;
+            let bytes: Vec<_> = entry.bytes().filter_map(|data| data.ok()).collect();
+            let content = String::from_utf8(bytes).ok()?;
+            Some((path, content))
+        }) {
             let file_id = FileId::new(Some(spec.clone()), VirtualPath::new(path));
             if files_done.contains(&file_id) {
                 continue;
             }
-            let Ok(Some(source)) = cache.lookup_cached::<Source>(&spec, file_id) else {
-                continue;
-            };
+            let source = parse(&content);
             populate_packages(source, &mut package_stack, &packages_done);
             files_done.insert(file_id);
         }
-        dbg!(cache.cache_archive(Archive::new(&archive_bytes[..]), &spec));
+        let Ok(_) = cache.cache_archive(Archive::new(&archive_bytes[..]), &spec) else {
+            packages_failed.insert(spec);
+            continue;
+        };
         packages_done.insert(spec);
     }
+    debug_assert!(packages_failed.len() == 0);
     Ok(packages_done)
 }
 
@@ -582,22 +588,16 @@ mod test_async_packages {
     use std::iter;
     use tokio;
 
-    use typst::syntax::{FileId, Source, VirtualPath, parse};
+    use typst::syntax::{FileId, Source, VirtualPath};
 
-    use crate::{
-        cached_file_resolver::CachedFileResolver,
-        file_resolver::FileResolver,
-        package_resolver::{
-            PackageResolver, PackageResolverCache, async_prepopulate_dependencies,
-            populate_packages,
-        },
-    };
+    use crate::package_resolver::{PackageResolver, async_prepopulate_dependencies};
 
     const LOTS_OF_IMPORTS: &str = r#"
 #import "@preview/cetz:0.5.2"
-#import     "@preview/fletcher:0.5.8"
+#import "@preview/fletcher:0.5.8"
 #import "@preview/timeliney:0.4.0"
 #import "@preview/pinit:0.2.2"
+#import "@preview/deckz:0.3.1"
 "#;
     #[tokio::test]
     async fn fetch_packages() {


### PR DESCRIPTION
Continuation/successor implementation of #16.

Aims to support packages on web by pre-populating the package cache outside of the normal compilation context, meeting the web requirement for non-blocking IO by figuring out what we'll need ahead of time.

Draft because I need a little help with this, as I'm not sure where this should live in the API as it's currently designed. This needs access to the template's sources and a package cache, but I can't identify a clear spot to slot this in.

The test added (+ the tokio dev dependency) can be removed before merging, as this was mostly for development purposes.